### PR TITLE
Refactor

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
--I. --color
+-I. --color --format documentation

--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -5,12 +5,8 @@ def update_quality(items)
       multiple = quality_change_multiple(item)
       update_item_quality(item, multiple)
     end
-    update_item_sell_in(item)
+    item.sell_in -= 1
   end
-end
-
-def update_item_sell_in(item)
-  item.sell_in -= 1
 end
 
 def quality_change_multiple(item)

--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -32,16 +32,19 @@ end
 def update_item_quality(item, multiple)
   case item.name
   when 'Aged Brie'
-    item.quality += [50 - item.quality, multiple].min
+    item.quality += multiple
   when 'Backstage passes to a TAFKAL80ETC concert'
     if item.sell_in > 0
-      item.quality += [50 - item.quality, multiple].min
+      item.quality += multiple
     else
       item.quality = 0
     end
+  when /^Conjured/
+    item.quality -= (2 * multiple)
   else
-    item.quality -= [item.quality, multiple].min
+    item.quality -= multiple
   end
+  item.quality = [[0, item.quality].max, 50].min
 end
 
 #----------------------------

--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -1,53 +1,50 @@
 def update_quality(items)
   items.each do |item|
-    if item.name != 'Aged Brie' && item.name != 'Backstage passes to a TAFKAL80ETC concert'
-      if item.quality > 0
-        if item.name != 'Sulfuras, Hand of Ragnaros'
-          item.quality -= 1
-        end
-      end
+    next if item.name == 'Sulfuras, Hand of Ragnaros'
+    if item.quality < 50
+      multiple = quality_change_multiple(item)
+      update_item_quality(item, multiple)
+    end
+    update_item_sell_in(item)
+  end
+end
+
+def update_item_sell_in(item)
+  item.sell_in -= 1
+end
+
+def quality_change_multiple(item)
+  if item.name == 'Backstage passes to a TAFKAL80ETC concert'
+    if item.sell_in <= 5
+      3
+    elsif item.sell_in <= 10
+      2
     else
-      if item.quality < 50
-        item.quality += 1
-        if item.name == 'Backstage passes to a TAFKAL80ETC concert'
-          if item.sell_in < 11
-            if item.quality < 50
-              item.quality += 1
-            end
-          end
-          if item.sell_in < 6
-            if item.quality < 50
-              item.quality += 1
-            end
-          end
-        end
-      end
+      1
     end
-    if item.name != 'Sulfuras, Hand of Ragnaros'
-      item.sell_in -= 1
+  elsif item.sell_in <= 0
+    2
+  else
+    1
+  end
+end
+
+def update_item_quality(item, multiple)
+  case item.name
+  when 'Aged Brie'
+    item.quality += [50 - item.quality, multiple].min
+  when 'Backstage passes to a TAFKAL80ETC concert'
+    if item.sell_in > 0
+      item.quality += [50 - item.quality, multiple].min
+    else
+      item.quality = 0
     end
-    if item.sell_in < 0
-      if item.name != "Aged Brie"
-        if item.name != 'Backstage passes to a TAFKAL80ETC concert'
-          if item.quality > 0
-            if item.name != 'Sulfuras, Hand of Ragnaros'
-              item.quality -= 1
-            end
-          end
-        else
-          item.quality = item.quality - item.quality
-        end
-      else
-        if item.quality < 50
-          item.quality += 1
-        end
-      end
-    end
+  else
+    item.quality -= [item.quality, multiple].min
   end
 end
 
 #----------------------------
 # DO NOT CHANGE THINGS BELOW
 #----------------------------
-
 Item = Struct.new(:name, :sell_in, :quality)

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -191,36 +191,36 @@ RSpec.describe '#update_quality' do
       context 'before the sell date' do
         let(:initial_sell_in) { 5 }
 
-        xit { expect(item.quality).to eq(initial_quality - 2) }
+        it { expect(item.quality).to eq(initial_quality - 2) }
 
         context 'at zero quality' do
           let(:initial_quality) { 0 }
 
-          xit { expect(item.quality).to eq(initial_quality) }
+          it { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context 'on sell date' do
         let(:initial_sell_in) { 0 }
 
-        xit { expect(item.quality).to eq(initial_quality - 4) }
+        it { expect(item.quality).to eq(initial_quality - 4) }
 
         context 'at zero quality' do
           let(:initial_quality) { 0 }
 
-          xit { expect(item.quality).to eq(initial_quality) }
+          it { expect(item.quality).to eq(initial_quality) }
         end
       end
 
       context 'after sell date' do
         let(:initial_sell_in) { -10 }
 
-        xit { expect(item.quality).to eq(initial_quality - 4) }
+        it { expect(item.quality).to eq(initial_quality - 4) }
 
         context 'at zero quality' do
           let(:initial_quality) { 0 }
 
-          xit { expect(item.quality).to eq(initial_quality) }
+          it { expect(item.quality).to eq(initial_quality) }
         end
       end
     end


### PR DESCRIPTION
This PR:

- refactors the `#update_quality` method to make it easier to read and modify, by splitting it into 3 methods and re-organizing the logic.
- adds  a new rule for `Conjured` items, whose quality decays twice as fast as normal items.